### PR TITLE
先提交Ubiketable Componets的部分 另外，有些疑問想要詢問老師 謝謝

### DIFF
--- a/src/views/uBikeTable/components/pagination.vue
+++ b/src/views/uBikeTable/components/pagination.vue
@@ -1,0 +1,69 @@
+<script setup>
+import { toRefs, ref, computed } from 'vue';
+
+const props = defineProps({
+    currentPage: {
+        type: Number
+    },
+    totalPageCount: {
+        type: Number
+    },
+    PAGINATION_MAX: {
+        type: Number
+    }
+})
+
+const { currentPage, totalPageCount } = toRefs(props);
+
+const emit = defineEmits(['updateCurrentPage'])
+
+// const currentPage = ref(props.currentPage);
+// const totalPageCount = ref(props.totalPageCount);
+const PAGINATION_MAX = props.PAGINATION_MAX;
+
+// 分頁的尾端
+const pagerEnd = computed(() => {
+    return totalPageCount.value <= PAGINATION_MAX
+        ? totalPageCount.value
+        : PAGINATION_MAX;
+});
+// 分頁的位移，用來確保目前的頁碼在中間
+const pagerAddAmount = computed(() => {
+    const tmp =
+        totalPageCount.value <= PAGINATION_MAX
+            ? 0
+            : currentPage.value + 4 - pagerEnd.value;
+    return tmp <= 0
+        ? 0
+        : totalPageCount.value - (PAGINATION_MAX + tmp) < 0
+            ? totalPageCount.value - PAGINATION_MAX
+            : tmp;
+});
+// 換頁
+const setPage = page => {
+    if (page < 1 || page > totalPageCount.value) {
+        return;
+    }
+    // currentPage.value = page;
+    emit('updateCurrentPage', page)
+};
+</script>
+
+<template>
+    <nav v-if="pagerEnd > 0">
+        <ul class="pagination">
+            <li @click.prevent="setPage(currentPage - 1)" class="page-item">
+                <a class="page-link" href>Previous</a>
+            </li>
+
+            <li v-for="i in pagerEnd" :class="{ active: i + pagerAddAmount === currentPage }" :key="i"
+                @click.prevent="setPage(i + pagerAddAmount)" class="page-item">
+                <a class="page-link" href>{{ i + pagerAddAmount }}</a>
+            </li>
+
+            <li @click.prevent="setPage(currentPage + 1)" class="page-item">
+                <a class="page-link" href>Next</a>
+            </li>
+        </ul>
+    </nav>
+</template>

--- a/src/views/uBikeTable/components/search.vue
+++ b/src/views/uBikeTable/components/search.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { ref, computed } from 'vue';
+const props = defineProps({
+    searchText: {
+        type: String
+    }
+})
+
+const emit = defineEmits(['change'])
+
+const searchText = computed({
+    get: () => {
+        return props.searchText
+    }
+    ,
+    set: (val) => {
+        emit('change', val)
+    }
+})
+
+</script>
+
+<template>
+    <p>
+        站點名稱搜尋: <input type="text" class="border" v-model.lazy="searchText">
+    </p>
+</template>

--- a/src/views/uBikeTable/components/uBikeTable.vue
+++ b/src/views/uBikeTable/components/uBikeTable.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+    slicedUbikeStops: {
+        type: Array
+    },
+    searchText: {
+        type: String
+    },
+    currentSort: {
+        type: String
+    },
+    isSortDesc: {
+        type: Boolean
+    }
+})
+
+const emit = defineEmits(['updateCurrentSort', 'updateIsSortDesc'])
+
+const currentSort = ref(props.currentSort);
+const isSortDesc = ref(props.isSortDesc);
+
+const update = () => {
+    emit('updateCurrentSort', currentSort.value);
+    emit('updateIsSortDesc', isSortDesc.value);
+}
+
+// 指定排序
+const setSort = sortType => {
+    if (sortType === currentSort.value) {
+        isSortDesc.value = !isSortDesc.value;
+        update();
+    } else {
+        currentSort.value = sortType;
+        isSortDesc.value = false;
+        update();
+    }
+};
+const timeFormat = (val) => {
+    // 時間格式
+    const pattern = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/;
+    return val.replace(pattern, '$1/$2/$3 $4:$5:$6');
+};
+// 關鍵字 Highlight
+const keywordsHighlight = (text, keyword) => {
+    const reg = new RegExp(keyword, 'gi');
+    return text.replace(reg, `<span style="color: red;">${keyword}</span>`);
+};
+</script>
+
+<template>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th @click="setSort('sno')">
+                    #
+                    <span v-show="currentSort === 'sno'">
+                        <i class="fa" :class="isSortDesc ? 'fa-sort-desc' : 'fa-sort-asc'" aria-hidden="true"></i>
+                    </span>
+                </th>
+                <th>
+                    場站名稱
+                </th>
+                <th>
+                    場站區域
+                </th>
+                <th @click="setSort('sbi')" class="pointer">
+                    目前可用車輛
+                    <span v-show="currentSort === 'sbi'">
+                        <i class="fa" :class="isSortDesc ? 'fa-sort-desc' : 'fa-sort-asc'" aria-hidden="true"></i>
+                    </span>
+                </th>
+                <th @click="setSort('tot')" class="pointer">
+                    總停車格
+                    <span v-show="currentSort === 'tot'">
+                        <i class="fa" :class="isSortDesc ? 'fa-sort-desc' : 'fa-sort-asc'" aria-hidden="true"></i>
+                    </span>
+                </th>
+                <th>
+                    資料更新時間
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- 替換成 slicedUbikeStops -->
+            <tr v-for="s in slicedUbikeStops" :key="s.sno">
+                <td>{{ s.sno }}</td>
+                <!-- <td>{{ s.sna }}</td> -->
+                <td v-html="keywordsHighlight(s.sna, searchText)"></td>
+                <td>{{ s.sarea }}</td>
+                <td>{{ s.sbi }}</td>
+                <td>{{ s.tot }}</td>
+                <td>{{ timeFormat(s.mday) }}</td>
+            </tr>
+        </tbody>
+    </table>
+</template>


### PR DESCRIPTION
關於toRefs，還有「樣式到了子層元件就無法生效」的問題 想要另外詢問老師

1. 在 uBikeTable 以及 pagination 這兩個子層元件中 都會發生樣式跑版的情況

- uBikeTable 標頭上的上下箭頭消失
 ![image](https://github.com/kurotanshi/5xruby-vue-202308-quiz-2/assets/90835355/73e72067-88aa-448a-b4b9-58ea78f73c1d)
- 在頁面左側而沒有置中
![image](https://github.com/kurotanshi/5xruby-vue-202308-quiz-2/assets/90835355/6d4bf434-94a8-4925-9d11-6224fadc5f6f)

但在父層元件原先都已經有定義了 雖然是scoped 但不是也會包含到子層的範圍嗎？
``` 
<style lang="scss" scoped>
.app {
  padding: 1rem;
}

.pointer {
  cursor: pointer;
}

.pagination {
  display: flex;
  justify-content: center;
}

@media (max-width: 768px) {
  .sno {
    max-width: 50px;
    word-wrap: break-word;
  }

  .table td,
  .table th {
    padding: .5rem .25rem;
  }
}
</style> 
```

我試著在子層元件引用 `import "bootstrap/dist/css/bootstrap.css"; `樣式效果也沒有生效

2. 關於toRefs 的疑問
為什麼會用到toRefs 是因為我原先的代碼是這樣寫：
```
const props = defineProps({
    currentPage: {
        type: Number
    },
    totalPageCount: {
        type: Number
    },
    PAGINATION_MAX: {
        type: Number
    }
})

const emit = defineEmits(['updateCurrentPage'])

const currentPage = ref(props.currentPage);
const totalPageCount = ref(props.totalPageCount);
const PAGINATION_MAX = props.PAGINATION_MAX;
```

雖然控制台沒有跳錯誤訊息，但畫面沒有把分頁渲染出來，開vue的除錯工具觀察發現，我在子層元件ref使用到的totalPageCount 是0，這個原因會是跟生命週期有關嗎？因為子層元件引入父層的值的時候totalPageCount 還沒有更新拿到filtedUbikeStops.value.length 的資料？這個問題該怎麼避免？
![image](https://github.com/kurotanshi/5xruby-vue-202308-quiz-2/assets/90835355/70c4de0d-8b88-4c08-bb52-e884d606b49c)

我試著用onMouted之後再取值也是一樣為0
```
let totalPageCount = ref(props.totalPageCount);

onMounted(()=>{
    totalPageCount = ref(props.totalPageCount);
})
```

後來請教gpt 他給的回覆雖然有點奇怪（因為我在子層中並沒有改變totalPageCount的值）
但我改成使用`toRefs`確實沒有問題了
![image](https://github.com/kurotanshi/5xruby-vue-202308-quiz-2/assets/90835355/f25583bd-cdc1-4605-9331-b7548e0f9b36)

但是這邊出現另外新的問題是在這邊跳出了警告`Set operation on key 'currentPage' failed: target is readonly`
所以我最後就直接把  `// currentPage.value = page;` 註解掉
```
// 換頁
const setPage = page => {
    if (page < 1 || page > totalPageCount.value) {
        return;
    }
    currentPage.value = page;
    emit('updateCurrentPage', page)
};
```
gpt這邊的問題感覺在亂回答(? XD
因為toRefs我看[官方文件](https://cn.vuejs.org/api/reactivity-utilities.html#torefs) 看起來應該還是具有響應性的？
`当从组合式函数中返回响应式对象时，toRefs 相当有用。使用它，消费者组件可以解构/展开返回的对象而不会失去响应性：`
![image](https://github.com/kurotanshi/5xruby-vue-202308-quiz-2/assets/90835355/69440977-c63b-4f47-9799-4fc79de2e239)

以上再麻煩老師幫忙解惑 謝謝！